### PR TITLE
Switch to bge-small-en-v1.5 and hybrid search

### DIFF
--- a/alembic/versions/h5c6d7e8f9a0_add_embedding_bge_small_15_column.py
+++ b/alembic/versions/h5c6d7e8f9a0_add_embedding_bge_small_15_column.py
@@ -1,0 +1,47 @@
+"""add embedding_bge_small_15 column to rules_vectors
+
+Revision ID: h5c6d7e8f9a0
+Revises: g4b5c6d7e8f9
+Create Date: 2026-03-12
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "h5c6d7e8f9a0"
+down_revision: Union[str, Sequence[str], None] = "g4b5c6d7e8f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Make existing embedding column nullable — only one embedding column will be
+    # populated per row depending on which model was used for ingestion.
+    op.execute(
+        "ALTER TABLE public.rules_vectors ALTER COLUMN embedding DROP NOT NULL;"
+    )
+    # Add new 384-dim column for BAAI/bge-small-en-v1.5 embeddings.
+    op.execute(
+        "ALTER TABLE public.rules_vectors ADD COLUMN embedding_bge_small_15 vector(384);"
+    )
+    # HNSW cosine index — same setup as the existing embedding index.
+    op.execute("""
+        CREATE INDEX rules_vectors_embedding_bge_small_15_hnsw_cosine
+          ON public.rules_vectors
+          USING hnsw (embedding_bge_small_15 vector_cosine_ops);
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS public.rules_vectors_embedding_bge_small_15_hnsw_cosine;"
+    )
+    op.execute(
+        "ALTER TABLE public.rules_vectors DROP COLUMN IF EXISTS embedding_bge_small_15;"
+    )
+    op.execute(
+        "ALTER TABLE public.rules_vectors ALTER COLUMN embedding SET NOT NULL;"
+    )

--- a/alembic/versions/i6d7e8f9a0b1_add_content_tsv_column.py
+++ b/alembic/versions/i6d7e8f9a0b1_add_content_tsv_column.py
@@ -1,0 +1,42 @@
+"""add content_tsv column to rules_vectors for full-text search
+
+Revision ID: i6d7e8f9a0b1
+Revises: h5c6d7e8f9a0
+Create Date: 2026-03-12
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "i6d7e8f9a0b1"
+down_revision: Union[str, Sequence[str], None] = "h5c6d7e8f9a0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE public.rules_vectors ADD COLUMN content_tsv tsvector;"
+    )
+    # Backfill existing rows with pre-computed tsvectors.
+    op.execute(
+        "UPDATE public.rules_vectors SET content_tsv = to_tsvector('pg_catalog.english', content);"
+    )
+    # GIN index for fast full-text search.
+    op.execute("""
+        CREATE INDEX rules_vectors_content_tsv_gin
+          ON public.rules_vectors
+          USING gin (content_tsv);
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS public.rules_vectors_content_tsv_gin;"
+    )
+    op.execute(
+        "ALTER TABLE public.rules_vectors DROP COLUMN IF EXISTS content_tsv;"
+    )

--- a/alembic/versions/j7e8f9a0b1c2_rename_embedding_bge_small_15_to_embedding.py
+++ b/alembic/versions/j7e8f9a0b1c2_rename_embedding_bge_small_15_to_embedding.py
@@ -1,0 +1,48 @@
+"""rename embedding_bge_small_15 to embedding (drop old embedding column)
+
+Revision ID: j7e8f9a0b1c2
+Revises: i6d7e8f9a0b1
+Create Date: 2026-03-13
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "j7e8f9a0b1c2"
+down_revision: Union[str, Sequence[str], None] = "i6d7e8f9a0b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the old 768-dim embedding column and its index.
+    op.execute(
+        "DROP INDEX IF EXISTS public.rules_vectors_embedding_hnsw_cosine;"
+    )
+    op.execute(
+        "ALTER TABLE public.rules_vectors DROP COLUMN IF EXISTS embedding;"
+    )
+    # Rename the bge-small-en-v1.5 column to the canonical name.
+    op.execute(
+        "ALTER TABLE public.rules_vectors RENAME COLUMN embedding_bge_small_15 TO embedding;"
+    )
+    # Rename the associated HNSW index to match.
+    op.execute(
+        "ALTER INDEX IF EXISTS public.rules_vectors_embedding_bge_small_15_hnsw_cosine RENAME TO rules_vectors_embedding_hnsw_cosine;"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER INDEX IF EXISTS public.rules_vectors_embedding_hnsw_cosine RENAME TO rules_vectors_embedding_bge_small_15_hnsw_cosine;"
+    )
+    op.execute(
+        "ALTER TABLE public.rules_vectors RENAME COLUMN embedding TO embedding_bge_small_15;"
+    )
+    # Re-add the old column as nullable (original data is gone).
+    op.execute(
+        "ALTER TABLE public.rules_vectors ADD COLUMN embedding vector(768);"
+    )

--- a/compose.yaml
+++ b/compose.yaml
@@ -290,9 +290,10 @@ services:
       - --max-concurrent-requests
       - "5"
       - "--model-id"
-      - "jinaai/jina-embeddings-v2-base-en"
-      - "--pooling"
-      - "mean"
+      - BAAI/bge-small-en-v1.5
+      # - "jinaai/jina-embeddings-v2-base-en"
+      # - "--pooling"
+      # - "mean"
 
     volumes:
       # Cache model weights so they aren't re-downloaded each start

--- a/config-dev.yaml
+++ b/config-dev.yaml
@@ -23,8 +23,9 @@ chat:
 
 # Embedding Service Configuration
 embedding:
-  model: "jinaai/jina-embeddings-v2-base-en"
+  model: "BAAI/bge-small-en-v1.5"
   endpoint: "http://tei:80/v1"
+  query_instruction: "Represent this sentence for searching relevant passages: "
 
 # Data API Configuration
 data_api:

--- a/meeplemate/config.py
+++ b/meeplemate/config.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncIterator, Callable, Iterator, Literal, Optional, Se
 import os
 from langchain_postgres import PGEngine
 from meeplemate.postgres.vectorstore import PartitionedPGVectorStore
+from langchain_postgres.v2.hybrid_search_config import HybridSearchConfig, reciprocal_rank_fusion
 from langchain_postgres.v2.indexes import DistanceStrategy
 import yaml
 from dataclasses import dataclass
@@ -45,7 +46,7 @@ from meeplemate.game_service import GameService
 from meeplemate.postgres.store import PostgresJSONStore, PostgresSerializableStore
 from meeplemate.qa_graph import QAService, build_qa_service
 from meeplemate.retrievers import build_retriever
-from meeplemate.llm_models import load_tgi_chat_model, load_tokenizer, sentence_transformer_to_hf_embeddings
+from meeplemate.llm_models import load_tgi_chat_model, load_tokenizer, sentence_transformer_to_hf_embeddings, wrap_embeddings_with_instructions
 from meeplemate.pdf import parse_pdf
 from meeplemate.qa import build_qa_chain
 from chainlit.data.base import BaseDataLayer
@@ -120,6 +121,8 @@ class EmbeddingServiceConfig(BaseModel):
     model: str = Field(description="Name/path of the embedding model")
     endpoint: str = Field(description="Embedding service endpoint URL")
     api_key: SecretStr = Field(description="API key for embedding service")
+    query_instruction: str = Field(default="", description="Instruction prefix for query embeddings")
+    embed_instruction: str = Field(default="", description="Instruction prefix for document embeddings")
 
     @field_validator('endpoint')
     @classmethod
@@ -441,7 +444,7 @@ def create_app_system(cfg: Config) -> System[AppServices]:
             #     create_session,
             #     ["db_cluster"]
             # ),
-            "embedding_model": (
+            "_embedding_model": (
                 factory(OpenAIEmbeddings)(
                     model=cfg.embedding.model,
                     base_url=cfg.embedding.endpoint,
@@ -450,6 +453,15 @@ def create_app_system(cfg: Config) -> System[AppServices]:
                     chunk_size=10,
                 ),
                 []
+            ),
+            "embedding_model": (
+                factory(wrap_embeddings_with_instructions)(
+                    query_instruction=cfg.embedding.query_instruction,
+                    embed_instruction=cfg.embedding.embed_instruction,
+                ),
+                {
+                    "embeddings": "_embedding_model",
+                }
             ),
             "vector_store": (
                 afactory(PartitionedPGVectorStore.create)(
@@ -461,6 +473,14 @@ def create_app_system(cfg: Config) -> System[AppServices]:
                     metadata_columns=["game_version", "game_id"],
                     metadata_json_column="langchain_metadata",
                     distance_strategy=DistanceStrategy.COSINE_DISTANCE,
+                    hybrid_search_config=HybridSearchConfig(
+                        tsv_column="content_tsv",
+                        tsv_lang="pg_catalog.english",
+                        fusion_function=reciprocal_rank_fusion,
+                        fusion_function_parameters={"rrf_k": 60},
+                        primary_top_k=50,
+                        secondary_top_k=50,
+                    ),
                 ),
                 {
                     "embedding_service": "embedding_model",

--- a/meeplemate/ingest/dataimport.py
+++ b/meeplemate/ingest/dataimport.py
@@ -110,6 +110,23 @@ def add_game_metadata_to_document(document: Document, gp: GamePackage) -> Docume
         "game_version": gp.get("game_version", ""),
     }
     document.metadata.update(game_metadata)
+
+    # We need to fix the doc_id reference for child chunks to their parent
+    if "doc_id" in document.metadata:
+        parent_doc_id = document.metadata["doc_id"]
+        # The parent doc ID will be the chunk ID which includes the page number, we need to replace that with the game version
+        parts = parent_doc_id.split("#")
+        if len(parts) > 1:
+            parts[1] = gp.get("game_version", "")
+            document.metadata["doc_id"] = "#".join(parts)
+
+    # We also need to fix the ID for chunks as that includes the version number
+    assert document.id and isinstance(document.id, str), "Document must have a string ID"
+    parts = document.id.split("#")
+    if len(parts) > 1:
+        parts[1] = gp.get("game_version", "")
+        document.id = "#".join(parts)
+
     return document
 
 

--- a/meeplemate/llm_models.py
+++ b/meeplemate/llm_models.py
@@ -1,5 +1,5 @@
 from types import MethodType
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast, override
 import inspect
 from langchain_core.outputs import Generation, GenerationChunk, LLMResult, RunInfo
 from langchain_core.callbacks import (
@@ -21,13 +21,61 @@ from transformers import (
 # import langchain_huggingface.chat_models as hfcm
 from sentence_transformers import SentenceTransformer
 from langchain_core.embeddings import Embeddings
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Dict, Any
 from sentence_transformers import SentenceTransformer
 # from text_generation.types import Details
 
 import requests
 from urllib.parse import urljoin
+
+
+class EmbeddingInstructionsWrapper(BaseModel, Embeddings):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    embeddings: Embeddings
+    query_instruction: str = Field(default="")
+    embed_instruction: str = Field(default="")
+
+    @override
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        texts = [f"{self.embed_instruction}{text}" for text in texts]
+        result = self.embeddings.embed_documents(texts)
+        return result
+
+    @override
+    def embed_query(self, text: str) -> list[float]:
+        text = f"{self.query_instruction}{text}"
+        result = self.embeddings.embed_query(text)
+        return result
+
+    @override
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        texts = [f"{self.embed_instruction}{text}" for text in texts]
+        result = await self.embeddings.aembed_documents(texts)
+        return result
+
+    @override
+    async def aembed_query(self, text: str) -> list[float]:
+        text = f"{self.query_instruction}{text}"
+        result = await self.embeddings.aembed_query(text)
+        return result
+
+
+def wrap_embeddings_with_instructions(embeddings: Embeddings, query_instruction:str = "", embed_instruction:str = "") -> Embeddings:
+    """
+    Wrap the given embeddings with instructions for the query and embed methods.
+
+    This is useful for models that require special instructions to be prepended to the input text in order to produce good embeddings. For example, some models may require a prefix like "Query: " for query embeddings and "Document: " for document embeddings.
+
+    By using this wrapper, you can keep the instruction logic separate from the core embedding logic, and easily apply it to any existing Embeddings implementation.
+    """
+    return EmbeddingInstructionsWrapper(
+        embeddings=embeddings,
+        query_instruction=query_instruction,
+        embed_instruction=embed_instruction,
+    )
+
 
 class HuggingFaceChatModelLocal(ChatHuggingFace):
     """

--- a/meeplemate/search.py
+++ b/meeplemate/search.py
@@ -1,3 +1,4 @@
+import dataclasses
 from dataclasses import dataclass
 from operator import itemgetter
 from typing import Annotated, Any, Literal, NotRequired, Optional, Sequence, TypedDict, List, cast
@@ -520,6 +521,17 @@ def build_chunk_search_service_2(
     tokenizer: Any,
     default_token_budget: int = 13000,
 ):
+    # If the vectorstore has a HybridSearchConfig, we grab it once here so we
+    # can create a fresh per-query copy on each call.  This avoids two bugs in
+    # the langchain-postgres library:
+    #   1. asimilarity_search_with_relevance_scores applies a "1 - score"
+    #      cosine transform to RRF scores, reversing their order and breaking
+    #      the descending-order assertion in find_cutoff_adaptive_k.
+    #   2. The library mutates hybrid_search_config.fts_query on the first
+    #      call; subsequent calls then re-use the stale first-query FTS string
+    #      regardless of the actual query.
+    _base_hybrid_config = getattr(getattr(vectorstore, '_vs', None), 'hybrid_search_config', None)
+
     @chain
     async def chain_func(input: ChunkSearchServiceInput) -> ChunkSearchOutputState:
         budget = input.get("token_budget", default_token_budget)
@@ -543,11 +555,20 @@ def build_chunk_search_service_2(
         for q in query:
             # Step 1: Retrieve a large set of potentially relevant chunks using
             # the vectorstore
-            docs_and_scores = await vectorstore.asimilarity_search_with_relevance_scores(
+            extra: dict = {}
+            if _base_hybrid_config is not None:
+                # Build a fresh per-query config so fts_query is always current
+                # and the shared instance config object is never mutated.
+                extra['hybrid_search_config'] = dataclasses.replace(_base_hybrid_config, fts_query=q)
+            docs_and_scores = await vectorstore.asimilarity_search_with_score(
                 q,
                 filter=filter,
-                k=50
+                k=50,
+                **extra
             )
+            # RRF scores (higher = better) are already sorted descending by the
+            # fusion function, but sort explicitly to be safe.
+            docs_and_scores.sort(key=lambda x: x[1], reverse=True)
             logger.info("Vectorstore returned", query=q, result_count=len(docs_and_scores))
 
             # Step 2: Use the adaptive k algorithm to find the cutoff point in


### PR DESCRIPTION
From eval, this smaller embedding model with hybrid search does just as well as `jina-embeddings-v2-base-en` but at a smaller parameter count. The one downside is that the jina embedding model supports longer texts than the bge one. However, we really only generate embeddings for smaller texts, so we will avail ourselves of the smaller parameter count, especially because we'd like to run the embedding model on the CPU.

Resolves #19 